### PR TITLE
12 search history list

### DIFF
--- a/assets/js/search-history.js
+++ b/assets/js/search-history.js
@@ -3,7 +3,12 @@ let searchHistory = new Set();
 function addSearchHistory(item) {
     if (!searchHistory.has(item)) {
         searchHistory.add(item);
-        localStorage.setItem("searchHistory", JSON.stringify(searchHistory));
+        localStorage.setItem("searchHistory", JSON.stringify([...searchHistory]));
         // Update display of search history results
     }
+}
+
+function getSearchHistory() {
+    searchHistory = new Set(JSON.parse(localStorage.getItem("searchHistory")));
+    // Update display of search history results
 }

--- a/assets/js/search-history.js
+++ b/assets/js/search-history.js
@@ -1,0 +1,9 @@
+let searchHistory = new Set();
+
+function addSearchHistory(item) {
+    if (!searchHistory.has(item)) {
+        searchHistory.add(item);
+        localStorage.setItem("searchHistory", JSON.stringify(searchHistory));
+        // Update display of search history results
+    }
+}

--- a/assets/js/search-history.js
+++ b/assets/js/search-history.js
@@ -4,11 +4,25 @@ function addSearchHistory(item) {
     if (!searchHistory.has(item)) {
         searchHistory.add(item);
         localStorage.setItem("searchHistory", JSON.stringify([...searchHistory]));
-        // Update display of search history results
+        displaySearchHistory()
     }
 }
 
 function getSearchHistory() {
     searchHistory = new Set(JSON.parse(localStorage.getItem("searchHistory")));
-    // Update display of search history results
+    displaySearchHistory()
 }
+
+function displaySearchHistory() {
+    $("#searchList").html("");
+    if (searchHistory.size === 0) {
+        $("#searchList").append("<li>No search history at this time...</li>");
+    } else {
+        [...searchHistory].reverse().forEach((item) => {
+            const el = $(`<li class="search-history-item">${item}</li>`);
+            $("#searchList").append(el);
+        });
+    }
+}
+
+getSearchHistory();

--- a/assets/js/search-history.js
+++ b/assets/js/search-history.js
@@ -19,10 +19,18 @@ function displaySearchHistory() {
         $("#searchList").append("<li>No search history at this time...</li>");
     } else {
         [...searchHistory].reverse().forEach((item) => {
-            const el = $(`<li class="search-history-item">${item}</li>`);
-            $("#searchList").append(el);
+            // Add the function for performing searches to the `onClick` attribute
+            const li = $('<li class="search-history-item">');
+            const btn = $(`<button class="button">${item}</button>`);
+            
+            // Replace this callback with whatever the function is for fetching data
+            btn.click(() => { console.log(`${item} clicked`) });
+
+            li.append(btn);
+            $("#searchList").append(li);
         });
     }
 }
 
-getSearchHistory();
+addSearchHistory("48823");
+addSearchHistory("12345");

--- a/index.html
+++ b/index.html
@@ -56,6 +56,9 @@
                 this is for the results 
               </div>        </div>
       </div>
+
+      <!--jQuery-->
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
    
       <script src="assets/js/api-endpoints.js"></script>
       <script src="assets//js/zip-to-coords.js"></script>

--- a/index.html
+++ b/index.html
@@ -59,6 +59,7 @@
    
       <script src="assets/js/api-endpoints.js"></script>
       <script src="assets//js/zip-to-coords.js"></script>
+      <script src="assets/js/search-history.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
Closes #12 

Provides functions for adding and getting the search history from local storage, as well as displaying the search history. Use the Set object to keep track of data, and prevent any duplicate items from being added.

`addSearchHistory`: Checks to see if the item already exists in the set, and if it doesn't, adds it to the set, saves everything to the local storage, and displays the new result

`getSearchHistory`: Gets the search history from local storage and displays the result

`displaySearchHistory`: Displays the current search history. If there is no search history, it displays a message indicating it. The search history items will each be a button that calls a function to fetch data for that item (not created yet.)