### PR TITLE
Add script tag back that had search-history.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,6 +111,7 @@
     <script src="assets/js/api-endpoints.js"></script>
     <script src="assets//js/zip-to-coords.js"></script>
     <script src="./assets/js/zip-to-movies.js"></script>
+    <script src="./assets/js/search-history.js"></script>
     <script src="./assets/js/script.js"></script>
 
 


### PR DESCRIPTION
The script tag for `search-history.js` was accidentally removed when the pull request for issue #12 was merged with `main`. Resubmitting changes to add the script tag back to the HTML file.