### PR TITLE
Display showtimes in movie modal

### DIFF
--- a/assets/js/display-showtimes.js
+++ b/assets/js/display-showtimes.js
@@ -27,7 +27,7 @@ function getShowtimeListElement(movie) {
 function getTimesHtmlString(times) {
     let html = "";
     for (let i = 0; i < times.length; i++) {
-        html += `<span class="showtime-time">${times[i]}</span> `;
+        html += `<span class="showtimes-time">${times[i]}</span> `;
     }
     return html;
 }

--- a/assets/js/display-theaters.js
+++ b/assets/js/display-theaters.js
@@ -1,0 +1,15 @@
+let theatres = [];
+
+function getTheatres(movies) {
+    theatres = [];
+    movies.forEach((movie) => {
+        movie.showtimes.forEach(({ theatre }) => {
+            if (!theatreIdExists(theatre.id)) theatres.push(theatre)
+        })
+    })
+}
+
+// Helper function to check if a theater already exists in the `theatres` array
+function theatreIdExists(id) {
+    return theatres.some((theatre) => theatre.id === id)
+}

--- a/assets/js/display-theaters.js
+++ b/assets/js/display-theaters.js
@@ -1,15 +1,33 @@
-let theatres = [];
+function getShowtimeListElement(movie) {
+    const showtimeListEl = $('<ul id="showTimeList">');
+    const showtimesData = {};
+    movie.showtimes.forEach((showtime) => {
+        const { theatre: { id } } = showtime;
+        if (!showtimesData.hasOwnProperty(id)) {
+            showtimesData[id] = {
+                theatre: showtime.theatre.name,
+                times: []
+            }
+        }
+        showtimesData[id].times.push(moment(showtime.dateTime).format("HH:MM"));
+    });
 
-function getTheatres(movies) {
-    theatres = [];
-    movies.forEach((movie) => {
-        movie.showtimes.forEach(({ theatre }) => {
-            if (!theatreIdExists(theatre.id)) theatres.push(theatre)
-        })
-    })
+    for (let showtimes of Object.values(showtimesData)) {
+        const showtimeItemEl = $(
+            `<li class="showtimes-item">
+                ${showtimes.theatre} ${getTimesHtmlString(showtimes.times)}
+            </li>`
+        );
+        showtimeListEl.append(showtimeItemEl)
+    }
+
+    return showtimeListEl;
 }
 
-// Helper function to check if a theater already exists in the `theatres` array
-function theatreIdExists(id) {
-    return theatres.some((theatre) => theatre.id === id)
+function getTimesHtmlString(times) {
+    let html = "";
+    for (let i = 0; i < times.length; i++) {
+        html += `<span class="showtime-time">${times[i]}</span> `;
+    }
+    return html;
 }

--- a/assets/js/zip-to-movies.js
+++ b/assets/js/zip-to-movies.js
@@ -36,6 +36,8 @@ var getMovieInfo = function (input){
         '<span class="tag is-white is-normal">' + "Cast: " + result[i].topCast + '</span></br>' +
         '<span class="tag is-white is-normal">' + '<a href=' + result[i].officialUrl + ' target="_blank">visit official movie page</a></span></br>' +
         '<span class="content is-normal">' + "Description: " + result[i].longDescription + '</span>');
+    $("#movie-info").append('<h3 class="showtimes-header">Showtimes</h3>');
+    $("#movie-info").append(getShowtimeListElement(result[i]));
     $("#movie-modal").addClass("is-active");
 };
 

--- a/assets/js/zip-to-movies.js
+++ b/assets/js/zip-to-movies.js
@@ -14,6 +14,7 @@ function getMovies(zipcode) {
         result = data;
 //        console.log(movies);
         showMovies(movies);
+        return movies;
     });
 }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -12,3 +12,18 @@ header {
   font-size: 3rem;
   font-weight: 600;
 }
+
+.showtimes-header {
+  font-weight: bold;
+  font-size: 1.1rem;
+}
+
+.showtimes-item {
+  margin: 10px;
+}
+
+.showtimes-time {
+  background: #1ca352;
+  color: white;
+  font-weight: bold;
+}

--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
     <script src="./assets/js/zip-to-movies.js"></script>
     <script src="./assets/js/search-history.js"></script>
     <script src="./assets/js/script.js"></script>
-    <script src="./assets/js/display-theaters.js"></script>
+    <script src="./assets/js/display-showtimes.js"></script>
 
 </body>
 

--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
     <script src="./assets/js/zip-to-movies.js"></script>
     <script src="./assets/js/search-history.js"></script>
     <script src="./assets/js/script.js"></script>
-
+    <script src="./assets/js/display-theaters.js"></script>
 
 </body>
 


### PR DESCRIPTION
Closes #7 

This was originally just going to be for displaying theaters (which can be seen in earlier commits), but now it displays the theaters and showtimes in the movie modal.

`getShowtimeListElement`: This generates and returns a list element for displaying the theaters that a movie is playing at and the showtimes associated with that theater.

`getTimesHtmlString`: This generates and returns a bunch of span elements that display each individual showtime respectively.