### PR TITLE
Add HTTPS to TMS API call

### DIFF
--- a/assets/js/zip-to-movies.js
+++ b/assets/js/zip-to-movies.js
@@ -5,7 +5,7 @@ var movieName;
 function getMovies(zipcode) {
     $("#info").show();
     var fromDate = moment().format('YYYY-MM-DD');
-    movieApiUrl = 'http://data.tmsapi.com/v1.1/movies/showings?startDate=' + fromDate + '&zip=' + zipcode + '&api_key=' + mykey;
+    movieApiUrl = 'https://data.tmsapi.com/v1.1/movies/showings?startDate=' + fromDate + '&zip=' + zipcode + '&api_key=' + mykey;
     return fetch(movieApiUrl)
     .then(function (response) {
         data = response.json();


### PR DESCRIPTION
Closes #49 

I changed the API call for the TMS API to use HTTPS so the live app won't throw an error. I switched the GitHub page branch to this one so that I could test to see if it works, and it now performs the desired behavior.